### PR TITLE
fix: resolve Flex Message image display on desktop and address format…

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
 		"dotenv": "^16.4.7",
 		"express": "^4.21.2",
 		"mongoose": "^8.9.0",
-		"ngrok": "^5.0.0-beta.2"
+		"ngrok": "^5.0.0-beta.2",
+		"opencc-js": "^1.0.5"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "1.9.4",

--- a/src/models/messageModel.ts
+++ b/src/models/messageModel.ts
@@ -310,7 +310,7 @@ const sendRestaurantList = async (replyToken: string, userId: string) => {
 	const bubbles: messagingApi.FlexBubble[] = userPreferences.restaurants
 		.slice(startIndex, endIndex)
 		.map((restaurant, index): messagingApi.FlexBubble => {
-			// console.log(restaurant.imageUrl); // debug
+			// console.log(restaurant); // debug
 			return {
 				type: "bubble",
 				hero: {
@@ -523,7 +523,7 @@ const handleAddToFavorites = async (
 			userId,
 			restaurant.place_id,
 			restaurant.name,
-			restaurant.vicinity,
+			restaurantDetails.formatted_address,
 			restaurantDetails.geometry.location.lat || 0,
 			restaurantDetails.geometry.location.lng || 0,
 		);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2644,6 +2644,11 @@ onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
+opencc-js@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.npmmirror.com/opencc-js/-/opencc-js-1.0.5.tgz#4754a9407590c5d581c9b4788acd43e8627dd464"
+  integrity sha512-LD+1SoNnZdlRwtYTjnQdFrSVCAaYpuDqL5CkmOaHOkKoKh7mFxUicLTRVNLU5C+Jmi1vXQ3QL4jWdgSaa4sKjg==
+
 p-cancelable@^2.0.0:
   version "2.1.1"
   resolved "https://registry.npmmirror.com/p-cancelable/-/p-cancelable-2.1.1.tgz#aab7fbd416582fa32a3db49859c122487c5ed2cf"


### PR DESCRIPTION
<!-- 1. Verify and Update PR Title -->
<!-- Example PR Title: `[build | chore | ci | docs | feat | fix | perf | refactor | revert | style | test]: Fix page layout` -->

<!-- 2. Provide a detailed description of the changes -->

## Description

The issue arises because **LINE Flex Messages** on desktop do not handle image redirection (HTTP 302) as seamlessly as on mobile.

To fix this, implement a **manual redirection** to retrieve the final image URL:

1. Use an **API call** to intercept the `photo_reference` URL and resolve the redirection.
2. Replace the `photo_reference` link with the final image URL when sending the Flex Message.

**Example logic**:  
```ts
const getFinalPhotoUrl = async (
	photoReference: string,
	maxWidth = 400,
): Promise<string> => {
	const photoApiUrl = `https://maps.googleapis.com/maps/api/place/photo?maxwidth=${maxWidth}&photoreference=${photoReference}&key=${googleMapsApiKey}`;
	try {
		// 設定 axios 請求不跟隨重定向 (maxRedirects: 0)
		const response = await axios.get(photoApiUrl, {
			maxRedirects: 0, // 不跟隨重定向
			validateStatus: (status) => status === 302, // 接受 302
		});
		const finalUrl = response.headers.location;
		if (finalUrl) {
			return finalUrl;
		}
		throw new Error("未找到 Location header");
	} catch (error) {
		console.error("Error fetching final photo URL:", error);
		return "";
	}
};
```

This ensures that both mobile and desktop users see the image correctly without relying on auto-redirection.

<!-- 3. Link the Github Issue related to these changes -->

## Related tickets

https://github.com/pg56714/line-dine-mapper/issues/3

<!-- 4. Confirm the following before submitting your PR -->

## PR Checklist

- [x] I have read the [Contributing Guide](../.github/CONTRIBUTING.md).
- [x] I have written documentation and tests where necessary.